### PR TITLE
Fix bug in intrinsics output.

### DIFF
--- a/gaps/apps/scn2cam/scn2cam.cpp
+++ b/gaps/apps/scn2cam/scn2cam.cpp
@@ -344,8 +344,8 @@ WriteCameraIntrinsics(const char *filename)
   // Write file
   for (int i = 0; i < cameras.NEntries(); i++) {
     Camera *camera = cameras.Kth(i);
-    RNScalar fx = 0.5 * width / atan(camera->XFOV());
-    RNScalar fy = 0.5 * height / atan(camera->YFOV());
+    RNScalar fx = 0.5 * width / tan(camera->XFOV());
+    RNScalar fy = 0.5 * height / tan(camera->YFOV());
     fprintf(fp, "%g 0 %g   0 %g %g  0 0 1\n", fx, cx, fy, cy);
   }
 


### PR DESCRIPTION
The focal lengths in the output intrinsics file are wrong. According to the formula in [https://en.wikipedia.org/wiki/Angle_of_view](url), the atan should be tan.