### PR TITLE
keyboard zoom

### DIFF
--- a/gaps/apps/scnview/scnview.cpp
+++ b/gaps/apps/scnview/scnview.cpp
@@ -725,6 +725,17 @@ void GLUTKeyboard(unsigned char key, int x, int y)
     show_frame_rate = !show_frame_rate;
     break;
 
+  // keyboard zoom
+  case 'I':
+  case 'i':
+    viewer->ScaleWorld(center, 1.1);
+    break;
+
+  case 'O':
+  case 'o':
+    viewer->ScaleWorld(center, 0.9);
+    break;
+
   case 'V':
   case 'v':
     // Set camera


### PR DESCRIPTION
added keyboard zoom functionality (i: zoom in, o: zoom out), this makes working on a notebook without a mouse more convenient.